### PR TITLE
Fixed playlist selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.cache*
+.venv

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ CLIENT_ID = ""
 CLIENT_SECRET = ""
 REDIRECT_URI = "http://localhost:8888/callback"  # Set this to "http://localhost:8888/callback" to run it locally
 USERNAME = ""  # Put the username of the account registered with the API token
+PLAYLIST_NAME = "Liked Songs Export"
 
 scope = 'playlist-read-private playlist-read-collaborative playlist-modify-public playlist-modify-private user-library-read user-top-read'
 
@@ -19,8 +20,11 @@ token = util.prompt_for_user_token(
 
 sp = spotipy.Spotify(auth=token)
 
-sp.user_playlist_create(user=USERNAME, name="Liked Songs", public=False)
-playlist_id = sp.user_playlists(user=USERNAME)["items"][0]["id"]
+sp.user_playlist_create(user=USERNAME, name=PLAYLIST_NAME, public=False)
+playlists = sp.user_playlists(user=USERNAME)["items"]
+for playlist in playlists:
+	if playlist["name"] == PLAYLIST_NAME:
+		playlist_id = playlist["id"]
 
 song_list = []
 tracks = sp.current_user_saved_tracks(limit=50, offset=0)


### PR DESCRIPTION
At first, when I tried to use your script, I thought that it didn't work. But in fact it did work, although instead of filling the newly created playlist with the liked songs, it filled the first pinned playlist with them. While I was debugging about 3000 songs have been added to my "See Later" playlist, XD

So, now instead of matching the first playlist that comes up when calling user_playlists(), script matches the first playlist with the wanted name. While this still does not entirely eliminate the opportunity for some unwanted playlist to be chosen (e.g. the user has multiple playlists with the same name), it's an improvement.

Anyway, thanks for your work. Without your script I would be still stuck trying to use paid websites, being too lazy to research and write the script myself.